### PR TITLE
Support tags inside tags

### DIFF
--- a/html/dot.template
+++ b/html/dot.template
@@ -1,0 +1,6 @@
+digraph SG \{
+  [s
+    {item:tags "Tag: %" -> {item:title %}
+    }
+  ]
+\}

--- a/src/stuffkeeper-export-html.gob
+++ b/src/stuffkeeper-export-html.gob
@@ -379,7 +379,28 @@ class Stuffkeeper:Export:HTML from G:Object
                     g_free(esc);
 
                 }
-                else 
+                else if(buffer[i] == '{') {
+                    int a;
+                    int j = i+1;
+                    int depth = 0;
+                    while (buffer[j] || depth) {
+                        if (buffer[j]=='}')
+                        {
+                            if (!depth) break;
+                            depth--;
+                        }
+                        else if (buffer[j] == '{') depth++;
+                        j++;
+                    }
+                    // now i points to open { and  to matching close }
+                    if (i != j) // ensures buffer[j] doesn't segfault
+                    {
+                        buffer[j] = '\0';
+                        self_parse_field_buffer(self, buffer+i+1, fp_out);
+                        i=j;
+                    }
+                }
+                else
                 {
                     fputc(buffer[i], fp_out);
                 }
@@ -398,7 +419,7 @@ class Stuffkeeper:Export:HTML from G:Object
 
 
         a = fgetc(fp_in);
-        while(a != '}' && !depth) {
+        while(a != '}' || depth) {
             buffer[i] = a;
             i++;
             if(a == '}') depth--;
@@ -406,6 +427,12 @@ class Stuffkeeper:Export:HTML from G:Object
             a = fgetc(fp_in);
         };
         buffer[i] = '\0';
+        self_parse_field_buffer(self, buffer, fp_out);
+    }
+    private 
+    void 
+    parse_field_buffer(self,char* buffer, FILE *fp_out)
+    {
         if(strncasecmp(buffer, "escape:csv", 10) == 0)
         {
             self->_priv->etype = ESCAPE_CSV;


### PR DESCRIPTION
Works fine in the basic tests I've done.
One thing that's missing is the ability to escape stuff inside a tag, although that was missing before anyway (i.e. I don't think it was possible before to output a % character inside a tag.

Let me know if you want any changes.

The dot.template gives an example of why you might want this.
